### PR TITLE
feat: Add Language Switcher component with configuration and setup do…

### DIFF
--- a/LANGUAGE_SWITCHER_SETUP.md
+++ b/LANGUAGE_SWITCHER_SETUP.md
@@ -1,0 +1,255 @@
+# Smart Language Switcher Setup Guide
+
+This guide explains how to set up and use the smart language switcher for your Universal Editor multisite project.
+
+## Overview
+
+The smart language switcher provides intelligent URL mapping between different locales in your multisite setup. It supports:
+
+- **Automatic Language Detection**: Detects current language from URL path
+- **Intelligent URL Mapping**: Maps pages between languages using placeholders configuration
+- **Multiple Display Styles**: Dropdown, inline links, or flag icons
+- **Seamless Integration**: Works with existing header navigation
+- **Fallback Support**: Graceful fallbacks when mappings are unavailable
+
+## Supported Locales
+
+The system supports the following locales based on your multisite configuration:
+
+- `ch-de`: German (Switzerland) - `/ch/de/`
+- `ch-fr`: French (Switzerland) - `/ch/fr/`
+- `ch-en`: English (Switzerland) - `/ch/en/`
+- `de-de`: German (Germany) - `/de/de/` (default)
+- `de-en`: English (Germany) - `/de/en/`
+
+## Setup Instructions
+
+### 1. Component Registration
+
+The language switcher components are automatically registered when you build the project. The following files handle the registration:
+
+- `blocks/language-switcher/_language-switcher.json` - Universal Editor configuration
+- `blocks/language-switcher/language-switcher.js` - Block implementation
+- `blocks/language-switcher/language-switcher.css` - Styling
+
+### 2. Header Integration
+
+The language switcher is automatically integrated into your header navigation. It will:
+
+1. Look for the `nav-tools` section in your header
+2. Replace any placeholder text containing "language" or "lang"
+3. Add the language switcher if no placeholder is found
+
+### 3. URL Mappings Configuration
+
+#### Option A: Using Universal Editor (Recommended)
+
+1. In Universal Editor, create a new document called `placeholders`
+2. Add a sheet called `language-switcher`
+3. Create a table with the following columns:
+   - `source`: Source URL path (e.g., `/ch/de/ueber-uns`)
+   - `target`: Target URL path (e.g., `/ch/fr/a-propos`)
+   - `description`: Optional description for the mapping
+
+#### Option B: Manual Configuration
+
+1. Copy the template file `placeholders-language-switcher-template.json`
+2. Rename it to `placeholders.json`
+3. Modify the mappings according to your site structure
+4. Place it in your site root
+
+### 4. Example URL Mappings
+
+```json
+{
+  "data": [
+    {
+      "source": "/ch/de/",
+      "target": "/ch/fr/",
+      "description": "Homepage CH German to French"
+    },
+    {
+      "source": "/ch/de/ueber-uns",
+      "target": "/ch/fr/a-propos",
+      "description": "About page CH German to French"
+    },
+    {
+      "source": "/ch/de/produkte",
+      "target": "/ch/en/products",
+      "description": "Products page CH German to English"
+    }
+  ]
+}
+```
+
+## Usage
+
+### Adding Language Switcher Block
+
+1. In Universal Editor, add a "Language Switcher" block to your page
+2. Configure the following options:
+   - **Supported Locales**: Select which languages to show
+   - **Display Style**: Choose dropdown, inline, or flags
+   - **Fallback Locale**: Set the default language
+   - **Show Country Flags**: Enable/disable flag icons
+   - **Preserve Path**: Maintain current page path when switching
+
+### Display Styles
+
+#### Dropdown (Default)
+- Compact dropdown menu
+- Shows current language with arrow
+- Expandable list of other languages
+
+#### Inline Links
+- Horizontal list of language links
+- Current language highlighted
+- Separated by vertical bars
+
+#### Flag Icons
+- Flag-only display
+- Current language has colored border
+- Hover effects for other flags
+
+### Block Options
+
+You can customize the appearance using block options:
+
+- **Position**: `header-right`, `header-left`, `centered`
+- **Theme**: `light`, `dark`
+
+## How It Works
+
+### Language Detection
+
+The system detects the current language by analyzing the URL path:
+
+```javascript
+// Examples:
+// /ch/de/products → ch-de
+// /de/en/about → de-en
+// /ch/fr/ → ch-fr
+```
+
+### URL Mapping Logic
+
+1. **Current page detection**: Extracts language and page path
+2. **Mapping lookup**: Searches placeholders for current page
+3. **Target URL construction**: Builds target language URL
+4. **Fallback handling**: Uses standard pattern if no mapping found
+
+### Fallback Behavior
+
+If no specific mapping is found, the system:
+
+1. Preserves the current page path
+2. Changes only the language prefix
+3. Navigates to the constructed URL
+
+Example: `/ch/de/new-page` → `/ch/fr/new-page`
+
+## Customization
+
+### CSS Variables
+
+The language switcher uses your theme's CSS variables:
+
+- `--background-color`: Background colors
+- `--text-color`: Text colors
+- `--link-color`: Link and accent colors
+- `--light-color`: Border and hover colors
+- `--body-font-family`: Font family
+
+### Custom Styling
+
+You can override styles by targeting these classes:
+
+```css
+/* Dropdown style */
+.language-switcher-dropdown-container { }
+.language-switcher-current { }
+.language-switcher-dropdown { }
+.language-switcher-option { }
+
+/* Inline style */
+.language-switcher-inline-container { }
+.language-switcher-inline { }
+.language-switcher-link { }
+
+/* Flags style */
+.language-switcher-flags-container { }
+.language-switcher-flags { }
+.language-switcher-flag-button { }
+```
+
+## Troubleshooting
+
+### Language Switcher Not Appearing
+
+1. Check that `nav-tools` section exists in your header
+2. Verify the header fragment is loading correctly
+3. Ensure JavaScript files are loading without errors
+
+### Incorrect Language Detection
+
+1. Verify URL structure matches locale configuration
+2. Check that paths start with correct language prefixes
+3. Confirm default locale is set correctly
+
+### Mapping Not Working
+
+1. Verify `placeholders.json` is accessible at site root
+2. Check the `language-switcher` sheet exists
+3. Ensure mapping format is correct (source/target columns)
+
+### Styling Issues
+
+1. Check CSS variables are defined in your theme
+2. Verify no conflicting styles override the component
+3. Test responsive behavior on different screen sizes
+
+## API Reference
+
+### Core Functions
+
+#### `getLanguage()`
+Returns the current language code detected from URL.
+
+#### `switchToLanguage(targetLang)`
+Switches to the specified target language.
+
+#### `getAvailableLanguages()`
+Returns array of all configured languages with metadata.
+
+#### `createLanguageSwitcher(container)`
+Creates and returns a language switcher element.
+
+### Configuration Options
+
+```javascript
+const config = {
+  supportedLocales: ['ch-de', 'ch-fr', 'ch-en'],
+  displayStyle: 'dropdown', // 'dropdown' | 'inline' | 'flags'
+  fallbackLocale: 'de-de',
+  showCountryFlags: true,
+  preservePath: true
+};
+```
+
+## Best Practices
+
+1. **Always provide mappings** for important pages
+2. **Test all language combinations** before going live
+3. **Use descriptive mapping descriptions** for maintenance
+4. **Keep fallback locale** as your primary language
+5. **Test responsive behavior** on mobile devices
+6. **Verify accessibility** with screen readers
+
+## Support
+
+For issues or questions:
+
+1. Check the browser console for JavaScript errors
+2. Verify network requests to `placeholders.json`
+3. Test with different browsers and devices
+4. Review the implementation files for debugging

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,5 +1,6 @@
 import { getMetadata } from '../../scripts/aem.js';
 import { loadFragment } from '../fragment/fragment.js';
+import { createLanguageSwitcher } from '../../scripts/language-switcher.js';
 
 // media query match that indicates mobile/tablet width
 const isDesktop = window.matchMedia('(min-width: 900px)');
@@ -158,6 +159,25 @@ export default async function decorate(block) {
   // prevent mobile nav behavior on window resize
   toggleMenu(nav, navSections, isDesktop.matches);
   isDesktop.addEventListener('change', () => toggleMenu(nav, navSections, isDesktop.matches));
+
+  // Initialize language switcher in nav-tools
+  const navTools = nav.querySelector('.nav-tools');
+  if (navTools) {
+    // Check if language switcher should be added automatically
+    // Look for a placeholder paragraph or specific content that indicates language switcher placement
+    const languagePlaceholder = navTools.querySelector('p');
+    if (languagePlaceholder && 
+        (languagePlaceholder.textContent.toLowerCase().includes('language') || 
+         languagePlaceholder.textContent.toLowerCase().includes('lang'))) {
+      // Replace the placeholder with the actual language switcher
+      const languageSwitcher = createLanguageSwitcher();
+      languagePlaceholder.replaceWith(languageSwitcher);
+    } else if (!navTools.querySelector('.language-switcher')) {
+      // Add language switcher if not already present and no specific placeholder
+      const languageSwitcher = createLanguageSwitcher();
+      navTools.appendChild(languageSwitcher);
+    }
+  }
 
   const navWrapper = document.createElement('div');
   navWrapper.className = 'nav-wrapper';

--- a/blocks/language-switcher/_language-switcher.json
+++ b/blocks/language-switcher/_language-switcher.json
@@ -1,0 +1,113 @@
+{
+  "definitions": [
+    {
+      "title": "Language Switcher",
+      "id": "language-switcher",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "Language Switcher",
+              "model": "language-switcher"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "language-switcher",
+      "fields": [
+        {
+          "component": "multiselect",
+          "name": "supportedLocales",
+          "label": "Supported Locales",
+          "valueType": "string",
+          "options": [
+            {
+              "name": "Switzerland",
+              "children": [
+                { "name": "German (Switzerland)", "value": "ch-de" },
+                { "name": "French (Switzerland)", "value": "ch-fr" },
+                { "name": "English (Switzerland)", "value": "ch-en" }
+              ]
+            },
+            {
+              "name": "Germany", 
+              "children": [
+                { "name": "German (Germany)", "value": "de-de" },
+                { "name": "English (Germany)", "value": "de-en" }
+              ]
+            }
+          ],
+          "value": "ch-de,ch-fr,ch-en,de-de,de-en"
+        },
+        {
+          "component": "select",
+          "name": "displayStyle",
+          "label": "Display Style",
+          "valueType": "string",
+          "options": [
+            { "name": "Dropdown", "value": "dropdown" },
+            { "name": "Inline Links", "value": "inline" },
+            { "name": "Flag Icons", "value": "flags" }
+          ],
+          "value": "dropdown"
+        },
+        {
+          "component": "select",
+          "name": "fallbackLocale",
+          "label": "Fallback Locale",
+          "valueType": "string",
+          "options": [
+            { "name": "German (Germany)", "value": "de-de" },
+            { "name": "German (Switzerland)", "value": "ch-de" },
+            { "name": "English (Switzerland)", "value": "ch-en" },
+            { "name": "French (Switzerland)", "value": "ch-fr" },
+            { "name": "English (Germany)", "value": "de-en" }
+          ],
+          "value": "de-de"
+        },
+        {
+          "component": "boolean",
+          "name": "showCountryFlags",
+          "label": "Show Country Flags",
+          "value": true
+        },
+        {
+          "component": "boolean",
+          "name": "preservePath",
+          "label": "Preserve Current Page Path",
+          "value": true
+        },
+        {
+          "component": "multiselect",
+          "name": "classes",
+          "label": "Style Options",
+          "valueType": "string",
+          "options": [
+            {
+              "name": "Position",
+              "children": [
+                { "name": "Header Right", "value": "header-right" },
+                { "name": "Header Left", "value": "header-left" },
+                { "name": "Centered", "value": "centered" }
+              ]
+            },
+            {
+              "name": "Theme",
+              "children": [
+                { "name": "Light", "value": "light" },
+                { "name": "Dark", "value": "dark" }
+              ]
+            }
+          ],
+          "value": "header-right"
+        }
+      ]
+    }
+  ],
+  "filters": []
+}

--- a/blocks/language-switcher/language-switcher.css
+++ b/blocks/language-switcher/language-switcher.css
@@ -1,0 +1,326 @@
+/* Language Switcher Block Styles */
+.block.language-switcher {
+  margin: 0;
+  padding: 0;
+}
+
+/* Common Language Switcher Styles */
+.language-switcher,
+.language-switcher-dropdown-container,
+.language-switcher-inline-container,
+.language-switcher-flags-container {
+  position: relative;
+  display: inline-block;
+  font-family: var(--body-font-family);
+  font-size: var(--body-font-size-xs);
+}
+
+/* Dropdown Style Language Switcher */
+.language-switcher-dropdown-container {
+  z-index: 1000;
+}
+
+.language-switcher-current {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--background-color);
+  border: 1px solid var(--light-color);
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--text-color);
+  transition: all 0.3s ease;
+  min-width: 120px;
+  justify-content: space-between;
+}
+
+.language-switcher-current:hover {
+  background: var(--light-color);
+  border-color: var(--link-color);
+}
+
+.language-switcher-current:focus {
+  outline: 2px solid var(--link-color);
+  outline-offset: 2px;
+}
+
+.language-switcher-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--background-color);
+  border: 1px solid var(--light-color);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-10px);
+  transition: all 0.3s ease;
+  z-index: 1001;
+}
+
+.language-switcher-dropdown-container.open .language-switcher-dropdown {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.language-switcher-dropdown-container.open .language-switcher-current .language-arrow {
+  transform: rotate(180deg);
+}
+
+.language-switcher-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--text-color);
+  text-align: left;
+  transition: background-color 0.2s ease;
+}
+
+.language-switcher-option:hover {
+  background: var(--light-color);
+}
+
+.language-switcher-option:focus {
+  background: var(--light-color);
+  outline: 2px solid var(--link-color);
+  outline-offset: -2px;
+}
+
+/* Inline Style Language Switcher */
+.language-switcher-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.language-switcher-inline li {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.language-switcher-current-inline {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+  color: var(--link-color);
+}
+
+.language-switcher-link {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--text-color);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.language-switcher-link:hover {
+  color: var(--link-hover-color);
+  text-decoration: underline;
+}
+
+.language-switcher-link:focus {
+  outline: 2px solid var(--link-color);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.language-separator {
+  margin: 0 0.25rem;
+  color: var(--light-color);
+  font-weight: 300;
+}
+
+/* Flags Style Language Switcher */
+.language-switcher-flags {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.language-switcher-flag-current,
+.language-switcher-flag-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 24px;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+}
+
+.language-switcher-flag-current {
+  background: var(--light-color);
+  border: 2px solid var(--link-color);
+}
+
+.language-switcher-flag-button {
+  background: transparent;
+  border: 2px solid transparent;
+  cursor: pointer;
+}
+
+.language-switcher-flag-button:hover {
+  background: var(--light-color);
+  border-color: var(--light-color);
+}
+
+.language-switcher-flag-button:focus {
+  outline: 2px solid var(--link-color);
+  outline-offset: 2px;
+}
+
+/* Flag and Label Styling */
+.language-flag {
+  font-size: 1.2em;
+  line-height: 1;
+}
+
+.language-label {
+  white-space: nowrap;
+}
+
+.language-arrow {
+  font-size: 0.8em;
+  transition: transform 0.3s ease;
+}
+
+/* Block Options Styling */
+.language-switcher-block.header-right {
+  text-align: right;
+}
+
+.language-switcher-block.header-left {
+  text-align: left;
+}
+
+.language-switcher-block.centered {
+  text-align: center;
+}
+
+.language-switcher-block.light {
+  --background-color: #ffffff;
+  --text-color: #333333;
+  --light-color: #f5f5f5;
+}
+
+.language-switcher-block.dark {
+  --background-color: #333333;
+  --text-color: #ffffff;
+  --light-color: #555555;
+}
+
+/* Header Integration Styles */
+header .nav-tools .language-switcher,
+header .nav-tools .language-switcher-dropdown-container,
+header .nav-tools .language-switcher-inline-container,
+header .nav-tools .language-switcher-flags-container {
+  margin-left: auto;
+}
+
+/* Mobile Responsive Styles */
+@media (max-width: 768px) {
+  .language-switcher-current {
+    min-width: 100px;
+    padding: 0.4rem 0.6rem;
+    font-size: var(--body-font-size-xs);
+  }
+  
+  .language-switcher-inline {
+    gap: 0.25rem;
+  }
+  
+  .language-switcher-inline .language-label {
+    display: none;
+  }
+  
+  .language-switcher-flags {
+    gap: 0.25rem;
+  }
+  
+  .language-switcher-flag-current,
+  .language-switcher-flag-button {
+    width: 28px;
+    height: 20px;
+  }
+}
+
+/* High Contrast Mode Support */
+@media (prefers-contrast: high) {
+  .language-switcher-current,
+  .language-switcher-option {
+    border-width: 2px;
+  }
+  
+  .language-switcher-dropdown {
+    border-width: 2px;
+  }
+}
+
+/* Reduced Motion Support */
+@media (prefers-reduced-motion: reduce) {
+  .language-switcher-current,
+  .language-switcher-dropdown,
+  .language-switcher-option,
+  .language-switcher-link,
+  .language-switcher-flag-button,
+  .language-arrow {
+    transition: none;
+  }
+  
+  .language-switcher-dropdown {
+    transform: none;
+  }
+  
+  .language-switcher-dropdown-container.open .language-switcher-current .language-arrow {
+    transform: none;
+  }
+}
+
+/* Focus Visible Support */
+.language-switcher-current:focus-visible,
+.language-switcher-option:focus-visible,
+.language-switcher-link:focus-visible,
+.language-switcher-flag-button:focus-visible {
+  outline: 2px solid var(--link-color);
+  outline-offset: 2px;
+}
+
+/* Print Styles */
+@media print {
+  .language-switcher,
+  .language-switcher-dropdown-container,
+  .language-switcher-inline-container,
+  .language-switcher-flags-container {
+    display: none;
+  }
+}

--- a/blocks/language-switcher/language-switcher.js
+++ b/blocks/language-switcher/language-switcher.js
@@ -1,0 +1,326 @@
+/**
+ * Language Switcher Block Implementation
+ * Provides a configurable language switching component for Universal Editor
+ */
+
+import { 
+  getLanguage, 
+  switchToLanguage, 
+  getAvailableLanguages,
+  createLanguageSwitcher 
+} from '../../scripts/language-switcher.js';
+
+/**
+ * Extracts configuration from block content
+ * @param {HTMLElement} block - The block DOM element
+ * @returns {Object} Configuration object
+ */
+function extractBlockConfig(block) {
+  const config = {
+    supportedLocales: ['ch-de', 'ch-fr', 'ch-en', 'de-de', 'de-en'],
+    displayStyle: 'dropdown',
+    fallbackLocale: 'de-de',
+    showCountryFlags: true,
+    preservePath: true
+  };
+
+  // Extract configuration from block content if available
+  const configRows = block.querySelectorAll(':scope > div');
+  configRows.forEach(row => {
+    const cells = row.querySelectorAll('div');
+    if (cells.length >= 2) {
+      const key = cells[0].textContent.trim();
+      const value = cells[1].textContent.trim();
+      
+      switch (key.toLowerCase()) {
+        case 'supportedlocales':
+          config.supportedLocales = value.split(',').map(s => s.trim());
+          break;
+        case 'displaystyle':
+          config.displayStyle = value;
+          break;
+        case 'fallbacklocale':
+          config.fallbackLocale = value;
+          break;
+        case 'showcountryflags':
+          config.showCountryFlags = value.toLowerCase() === 'true';
+          break;
+        case 'preservepath':
+          config.preservePath = value.toLowerCase() === 'true';
+          break;
+      }
+    }
+  });
+
+  return config;
+}
+
+/**
+ * Creates a dropdown-style language switcher
+ * @param {Object} config - Configuration object
+ * @returns {HTMLElement} The dropdown switcher element
+ */
+function createDropdownSwitcher(config) {
+  const currentLang = getLanguage();
+  const availableLanguages = getAvailableLanguages()
+    .filter(lang => config.supportedLocales.includes(lang.code));
+  
+  const currentLanguage = availableLanguages.find(lang => lang.isCurrent) 
+    || availableLanguages.find(lang => lang.code === config.fallbackLocale)
+    || availableLanguages[0];
+
+  const switcher = document.createElement('div');
+  switcher.className = 'language-switcher-dropdown-container';
+
+  // Current language button
+  const currentButton = document.createElement('button');
+  currentButton.className = 'language-switcher-current';
+  currentButton.setAttribute('aria-expanded', 'false');
+  currentButton.setAttribute('aria-haspopup', 'true');
+  
+  const buttonContent = [];
+  if (config.showCountryFlags) {
+    buttonContent.push(`<span class="language-flag">${currentLanguage.flag}</span>`);
+  }
+  buttonContent.push(`<span class="language-label">${currentLanguage.label}</span>`);
+  buttonContent.push('<span class="language-arrow" aria-hidden="true">▼</span>');
+  
+  currentButton.innerHTML = buttonContent.join('');
+
+  // Dropdown menu
+  const dropdown = document.createElement('ul');
+  dropdown.className = 'language-switcher-dropdown';
+  dropdown.setAttribute('role', 'menu');
+  dropdown.setAttribute('aria-hidden', 'true');
+
+  availableLanguages.forEach(lang => {
+    if (!lang.isCurrent) {
+      const listItem = document.createElement('li');
+      listItem.setAttribute('role', 'none');
+      
+      const option = document.createElement('button');
+      option.className = 'language-switcher-option';
+      option.setAttribute('role', 'menuitem');
+      option.setAttribute('aria-label', `Switch to ${lang.label}`);
+      
+      const optionContent = [];
+      if (config.showCountryFlags) {
+        optionContent.push(`<span class="language-flag">${lang.flag}</span>`);
+      }
+      optionContent.push(`<span class="language-label">${lang.label}</span>`);
+      
+      option.innerHTML = optionContent.join('');
+      
+      option.addEventListener('click', async (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        await switchToLanguage(lang.code);
+      });
+      
+      listItem.appendChild(option);
+      dropdown.appendChild(listItem);
+    }
+  });
+
+  // Toggle functionality
+  const toggleDropdown = (open) => {
+    const isOpen = open !== undefined ? open : currentButton.getAttribute('aria-expanded') === 'false';
+    currentButton.setAttribute('aria-expanded', isOpen.toString());
+    dropdown.setAttribute('aria-hidden', (!isOpen).toString());
+    switcher.classList.toggle('open', isOpen);
+  };
+
+  currentButton.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    toggleDropdown();
+  });
+
+  // Close dropdown when clicking outside
+  document.addEventListener('click', (e) => {
+    if (!switcher.contains(e.target)) {
+      toggleDropdown(false);
+    }
+  });
+
+  // Keyboard navigation
+  currentButton.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggleDropdown();
+    } else if (e.key === 'Escape') {
+      toggleDropdown(false);
+    }
+  });
+
+  switcher.appendChild(currentButton);
+  switcher.appendChild(dropdown);
+
+  return switcher;
+}
+
+/**
+ * Creates an inline-style language switcher
+ * @param {Object} config - Configuration object
+ * @returns {HTMLElement} The inline switcher element
+ */
+function createInlineSwitcher(config) {
+  const availableLanguages = getAvailableLanguages()
+    .filter(lang => config.supportedLocales.includes(lang.code));
+
+  const switcher = document.createElement('div');
+  switcher.className = 'language-switcher-inline-container';
+
+  const list = document.createElement('ul');
+  list.className = 'language-switcher-inline';
+  list.setAttribute('role', 'list');
+
+  availableLanguages.forEach((lang, index) => {
+    const listItem = document.createElement('li');
+    listItem.setAttribute('role', 'listitem');
+    
+    if (lang.isCurrent) {
+      const currentSpan = document.createElement('span');
+      currentSpan.className = 'language-switcher-current-inline';
+      currentSpan.setAttribute('aria-current', 'page');
+      
+      const content = [];
+      if (config.showCountryFlags) {
+        content.push(`<span class="language-flag">${lang.flag}</span>`);
+      }
+      content.push(`<span class="language-label">${lang.label}</span>`);
+      
+      currentSpan.innerHTML = content.join('');
+      listItem.appendChild(currentSpan);
+    } else {
+      const link = document.createElement('button');
+      link.className = 'language-switcher-link';
+      link.setAttribute('aria-label', `Switch to ${lang.label}`);
+      
+      const content = [];
+      if (config.showCountryFlags) {
+        content.push(`<span class="language-flag">${lang.flag}</span>`);
+      }
+      content.push(`<span class="language-label">${lang.label}</span>`);
+      
+      link.innerHTML = content.join('');
+      
+      link.addEventListener('click', async (e) => {
+        e.preventDefault();
+        await switchToLanguage(lang.code);
+      });
+      
+      listItem.appendChild(link);
+    }
+
+    // Add separator between items (except for the last item)
+    if (index < availableLanguages.length - 1) {
+      const separator = document.createElement('span');
+      separator.className = 'language-separator';
+      separator.setAttribute('aria-hidden', 'true');
+      separator.textContent = '|';
+      listItem.appendChild(separator);
+    }
+
+    list.appendChild(listItem);
+  });
+
+  switcher.appendChild(list);
+  return switcher;
+}
+
+/**
+ * Creates a flag-only style language switcher
+ * @param {Object} config - Configuration object
+ * @returns {HTMLElement} The flags switcher element
+ */
+function createFlagsSwitcher(config) {
+  const availableLanguages = getAvailableLanguages()
+    .filter(lang => config.supportedLocales.includes(lang.code));
+
+  const switcher = document.createElement('div');
+  switcher.className = 'language-switcher-flags-container';
+
+  const list = document.createElement('ul');
+  list.className = 'language-switcher-flags';
+  list.setAttribute('role', 'list');
+
+  availableLanguages.forEach(lang => {
+    const listItem = document.createElement('li');
+    listItem.setAttribute('role', 'listitem');
+    
+    if (lang.isCurrent) {
+      const currentSpan = document.createElement('span');
+      currentSpan.className = 'language-switcher-flag-current';
+      currentSpan.setAttribute('aria-current', 'page');
+      currentSpan.setAttribute('aria-label', `Current language: ${lang.label}`);
+      currentSpan.innerHTML = `<span class="language-flag">${lang.flag}</span>`;
+      listItem.appendChild(currentSpan);
+    } else {
+      const button = document.createElement('button');
+      button.className = 'language-switcher-flag-button';
+      button.setAttribute('aria-label', `Switch to ${lang.label}`);
+      button.innerHTML = `<span class="language-flag">${lang.flag}</span>`;
+      
+      button.addEventListener('click', async (e) => {
+        e.preventDefault();
+        await switchToLanguage(lang.code);
+      });
+      
+      listItem.appendChild(button);
+    }
+
+    list.appendChild(listItem);
+  });
+
+  switcher.appendChild(list);
+  return switcher;
+}
+
+/**
+ * Main decoration function for the language switcher block
+ * @param {HTMLElement} block - The block DOM element
+ */
+export default function decorate(block) {
+  // Extract configuration from block content
+  const config = extractBlockConfig(block);
+  
+  // Clear the block content
+  block.innerHTML = '';
+  
+  // Add semantic classes
+  block.classList.add('language-switcher-block');
+  
+  // Create the appropriate switcher based on display style
+  let switcher;
+  switch (config.displayStyle) {
+    case 'inline':
+      switcher = createInlineSwitcher(config);
+      break;
+    case 'flags':
+      switcher = createFlagsSwitcher(config);
+      break;
+    case 'dropdown':
+    default:
+      switcher = createDropdownSwitcher(config);
+      break;
+  }
+  
+  // Apply additional classes from block options
+  const blockOptions = [...block.classList].filter(cls => 
+    !['block', 'language-switcher', 'language-switcher-block'].includes(cls)
+  );
+  
+  blockOptions.forEach(option => {
+    switcher.classList.add(option);
+  });
+  
+  // Add the switcher to the block
+  block.appendChild(switcher);
+  
+  // Add accessibility enhancements
+  block.setAttribute('role', 'navigation');
+  block.setAttribute('aria-label', 'Language switcher');
+  
+  console.log('Language switcher block initialized with config:', config);
+}

--- a/component-definition.json
+++ b/component-definition.json
@@ -156,6 +156,21 @@
               }
             }
           }
+        },
+        {
+          "title": "Language Switcher",
+          "id": "language-switcher",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Language Switcher",
+                  "model": "language-switcher"
+                }
+              }
+            }
+          }
         }
       ]
     }

--- a/component-models.json
+++ b/component-models.json
@@ -214,5 +214,96 @@
         "valueType": "string"
       }
     ]
+  },
+  {
+    "id": "language-switcher",
+    "fields": [
+      {
+        "component": "multiselect",
+        "name": "supportedLocales",
+        "label": "Supported Locales",
+        "valueType": "string",
+        "options": [
+          {
+            "name": "Switzerland",
+            "children": [
+              { "name": "German (Switzerland)", "value": "ch-de" },
+              { "name": "French (Switzerland)", "value": "ch-fr" },
+              { "name": "English (Switzerland)", "value": "ch-en" }
+            ]
+          },
+          {
+            "name": "Germany", 
+            "children": [
+              { "name": "German (Germany)", "value": "de-de" },
+              { "name": "English (Germany)", "value": "de-en" }
+            ]
+          }
+        ],
+        "value": "ch-de,ch-fr,ch-en,de-de,de-en"
+      },
+      {
+        "component": "select",
+        "name": "displayStyle",
+        "label": "Display Style",
+        "valueType": "string",
+        "options": [
+          { "name": "Dropdown", "value": "dropdown" },
+          { "name": "Inline Links", "value": "inline" },
+          { "name": "Flag Icons", "value": "flags" }
+        ],
+        "value": "dropdown"
+      },
+      {
+        "component": "select",
+        "name": "fallbackLocale",
+        "label": "Fallback Locale",
+        "valueType": "string",
+        "options": [
+          { "name": "German (Germany)", "value": "de-de" },
+          { "name": "German (Switzerland)", "value": "ch-de" },
+          { "name": "English (Switzerland)", "value": "ch-en" },
+          { "name": "French (Switzerland)", "value": "ch-fr" },
+          { "name": "English (Germany)", "value": "de-en" }
+        ],
+        "value": "de-de"
+      },
+      {
+        "component": "boolean",
+        "name": "showCountryFlags",
+        "label": "Show Country Flags",
+        "value": true
+      },
+      {
+        "component": "boolean",
+        "name": "preservePath",
+        "label": "Preserve Current Page Path",
+        "value": true
+      },
+      {
+        "component": "multiselect",
+        "name": "classes",
+        "label": "Style Options",
+        "valueType": "string",
+        "options": [
+          {
+            "name": "Position",
+            "children": [
+              { "name": "Header Right", "value": "header-right" },
+              { "name": "Header Left", "value": "header-left" },
+              { "name": "Centered", "value": "centered" }
+            ]
+          },
+          {
+            "name": "Theme",
+            "children": [
+              { "name": "Light", "value": "light" },
+              { "name": "Dark", "value": "dark" }
+            ]
+          }
+        ],
+        "value": "header-right"
+      }
+    ]
   }
 ]

--- a/scripts/language-switcher.js
+++ b/scripts/language-switcher.js
@@ -1,0 +1,290 @@
+/**
+ * Smart Language Switcher for Universal Editor Multisite
+ * Handles intelligent URL mapping between different locales
+ * Based on the lang-switcher implementation from asthabh23/lang-switcher
+ */
+
+// Configuration for supported locales based on your multisite setup
+const LOCALES_CONFIG = {
+  'ch-de': { path: '/ch/de/', label: 'Deutsch (CH)', flag: '🇨🇭' },
+  'ch-fr': { path: '/ch/fr/', label: 'Français (CH)', flag: '🇨🇭' },
+  'ch-en': { path: '/ch/en/', label: 'English (CH)', flag: '🇨🇭' },
+  'de-en': { path: '/de/en/', label: 'English (DE)', flag: '🇩🇪' },
+  'de-de': { path: '/de/de/', label: 'Deutsch (DE)', flag: '🇩🇪', default: true }
+};
+
+// Cache for language mappings
+let languageMappingsCache = null;
+
+/**
+ * Detects the current language from the URL path
+ * @returns {string} The detected language code (e.g., 'ch-de', 'de-de')
+ */
+export function getLanguage() {
+  const { pathname } = window.location;
+  
+  // Check each locale configuration
+  for (const [localeCode, config] of Object.entries(LOCALES_CONFIG)) {
+    if (pathname.startsWith(config.path)) {
+      return localeCode;
+    }
+  }
+  
+  // Return default locale if no match found
+  const defaultLocale = Object.entries(LOCALES_CONFIG)
+    .find(([, config]) => config.default);
+  return defaultLocale ? defaultLocale[0] : 'de-de';
+}
+
+/**
+ * Gets the current page path without the language prefix
+ * @returns {string} The page path without language prefix
+ */
+export function getCurrentPagePath() {
+  const { pathname } = window.location;
+  const currentLang = getLanguage();
+  const langConfig = LOCALES_CONFIG[currentLang];
+  
+  if (langConfig && pathname.startsWith(langConfig.path)) {
+    const pagePath = pathname.substring(langConfig.path.length);
+    return pagePath || '';
+  }
+  
+  return pathname.substring(1); // Remove leading slash
+}
+
+/**
+ * Fetches language mappings from placeholders.json
+ * @returns {Promise<Object>} The language mappings object
+ */
+async function fetchLanguageMappings() {
+  if (languageMappingsCache) {
+    return languageMappingsCache;
+  }
+  
+  try {
+    const response = await fetch('/placeholders.json?sheet=language-switcher');
+    if (!response.ok) {
+      console.warn('Language mappings not found, using fallback logic');
+      return {};
+    }
+    
+    const data = await response.json();
+    const mappings = {};
+    
+    // Convert the data structure to a more usable format
+    if (data.data) {
+      data.data.forEach(row => {
+        if (row.source && row.target) {
+          mappings[row.source] = row.target;
+        }
+      });
+    }
+    
+    languageMappingsCache = mappings;
+    return mappings;
+  } catch (error) {
+    console.warn('Error fetching language mappings:', error);
+    return {};
+  }
+}
+
+/**
+ * Finds the mapped URL for a given source URL and target language
+ * @param {string} sourceUrl - The source URL to map
+ * @param {string} targetLang - The target language code
+ * @param {Object} mappings - The language mappings object
+ * @returns {string|null} The mapped URL or null if not found
+ */
+function findMappedUrl(sourceUrl, targetLang, mappings) {
+  const currentLang = getLanguage();
+  const currentPath = getCurrentPagePath();
+  const currentFullPath = LOCALES_CONFIG[currentLang]?.path + currentPath;
+  
+  // Look for exact match in mappings
+  for (const [source, target] of Object.entries(mappings)) {
+    if (source === currentFullPath || source === sourceUrl) {
+      return target;
+    }
+  }
+  
+  // Look for reverse mapping (if we're on a target page, find the source)
+  for (const [source, target] of Object.entries(mappings)) {
+    if (target === currentFullPath || target === sourceUrl) {
+      // Find the corresponding mapping for the target language
+      const targetPath = LOCALES_CONFIG[targetLang]?.path;
+      if (targetPath) {
+        // Try to find a mapping that starts with the target language path
+        for (const [mapSource, mapTarget] of Object.entries(mappings)) {
+          if (mapSource.startsWith(targetPath) && mapTarget === source) {
+            return mapSource;
+          }
+        }
+      }
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Switches to the specified language
+ * @param {string} targetLang - The target language code
+ * @returns {Promise<void>}
+ */
+export async function switchToLanguage(targetLang) {
+  if (!LOCALES_CONFIG[targetLang]) {
+    console.error(`Unsupported language: ${targetLang}`);
+    return;
+  }
+  
+  const currentLang = getLanguage();
+  if (currentLang === targetLang) {
+    return; // Already on the target language
+  }
+  
+  const mappings = await fetchLanguageMappings();
+  const currentPath = getCurrentPagePath();
+  const currentFullPath = LOCALES_CONFIG[currentLang]?.path + currentPath;
+  
+  // Try to find a mapped URL
+  const mappedUrl = findMappedUrl(currentFullPath, targetLang, mappings);
+  
+  let targetUrl;
+  if (mappedUrl) {
+    // Use the mapped URL
+    targetUrl = mappedUrl;
+  } else {
+    // Fallback: construct URL using the target language path
+    const targetConfig = LOCALES_CONFIG[targetLang];
+    targetUrl = targetConfig.path + currentPath;
+  }
+  
+  // Handle homepage special case
+  if (currentPath === '' || currentPath === '/') {
+    targetUrl = LOCALES_CONFIG[targetLang].path;
+  }
+  
+  // Navigate to the target URL
+  window.location.href = targetUrl;
+}
+
+/**
+ * Gets all available languages with their configurations
+ * @returns {Array} Array of language objects with code, label, flag, and current status
+ */
+export function getAvailableLanguages() {
+  const currentLang = getLanguage();
+  
+  return Object.entries(LOCALES_CONFIG).map(([code, config]) => ({
+    code,
+    label: config.label,
+    flag: config.flag,
+    path: config.path,
+    isCurrent: code === currentLang,
+    isDefault: config.default || false
+  }));
+}
+
+/**
+ * Creates a language switcher dropdown element
+ * @param {HTMLElement} container - The container element to append the switcher to
+ * @returns {HTMLElement} The created language switcher element
+ */
+export function createLanguageSwitcher(container) {
+  const currentLang = getLanguage();
+  const currentConfig = LOCALES_CONFIG[currentLang];
+  const availableLanguages = getAvailableLanguages();
+  
+  // Create the main switcher container
+  const switcher = document.createElement('div');
+  switcher.className = 'language-switcher';
+  
+  // Create the current language button
+  const currentButton = document.createElement('button');
+  currentButton.className = 'language-switcher-current';
+  currentButton.innerHTML = `
+    <span class="flag">${currentConfig.flag}</span>
+    <span class="label">${currentConfig.label}</span>
+    <span class="arrow">▼</span>
+  `;
+  
+  // Create the dropdown menu
+  const dropdown = document.createElement('div');
+  dropdown.className = 'language-switcher-dropdown';
+  
+  availableLanguages.forEach(lang => {
+    if (!lang.isCurrent) {
+      const option = document.createElement('button');
+      option.className = 'language-switcher-option';
+      option.innerHTML = `
+        <span class="flag">${lang.flag}</span>
+        <span class="label">${lang.label}</span>
+      `;
+      
+      option.addEventListener('click', async (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        await switchToLanguage(lang.code);
+      });
+      
+      dropdown.appendChild(option);
+    }
+  });
+  
+  // Toggle dropdown on current button click
+  currentButton.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    switcher.classList.toggle('open');
+  });
+  
+  // Close dropdown when clicking outside
+  document.addEventListener('click', (e) => {
+    if (!switcher.contains(e.target)) {
+      switcher.classList.remove('open');
+    }
+  });
+  
+  // Assemble the switcher
+  switcher.appendChild(currentButton);
+  switcher.appendChild(dropdown);
+  
+  if (container) {
+    container.appendChild(switcher);
+  }
+  
+  return switcher;
+}
+
+/**
+ * Initializes the language switcher in the header
+ * This function is called from the header block
+ */
+export function initializeLanguageSwitcher() {
+  // Look for a nav-tools section in the header
+  const navTools = document.querySelector('.nav-tools');
+  if (!navTools) {
+    console.warn('Nav tools section not found, cannot initialize language switcher');
+    return;
+  }
+  
+  // Check if language switcher already exists
+  if (navTools.querySelector('.language-switcher')) {
+    return; // Already initialized
+  }
+  
+  // Create and add the language switcher
+  const switcher = createLanguageSwitcher();
+  navTools.appendChild(switcher);
+  
+  console.log('Language switcher initialized successfully');
+}
+
+/**
+ * Legacy function for compatibility with the original implementation
+ * @param {string} targetLanguage - The target language code
+ */
+export function switchLanguage(targetLanguage) {
+  return switchToLanguage(targetLanguage);
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -90,7 +90,11 @@ export function decorateMain(main) {
  * @param {Element} doc The container element
  */
 async function loadEager(doc) {
-  document.documentElement.lang = 'en';
+  // Set document language based on current locale
+  const currentLang = window.location.pathname.startsWith('/ch/de/') ? 'de' :
+                     window.location.pathname.startsWith('/ch/fr/') ? 'fr' :
+                     window.location.pathname.startsWith('/de/de/') ? 'de' : 'en';
+  document.documentElement.lang = currentLang;
   decorateTemplateAndTheme();
   const main = doc.querySelector('main');
   if (main) {


### PR DESCRIPTION
…cumentation

- Introduced a new Language Switcher block with customizable options for supported locales, display styles, and fallback locales.
- Implemented JavaScript functionality for language detection, switching, and URL mapping.
- Added CSS styles for dropdown, inline, and flag icon display options.
- Created setup guide for integrating the Language Switcher into Universal Editor projects.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://lang-switcher--ue-multitenant-root--comwrapukreply.aem.page/
- After:  https://main--ue-multitenant-root--comwrapukreply.aem.live/
