### PR TITLE
Add function to open external links in a new tab

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -66,5 +66,32 @@ function createBackToTopButton() {
   }, { passive: true });
 }
 
+/**
+ * Opens external links in a new tab.
+ * Targets all anchors on the page whose href points to a different origin than the current page.
+ */
+function openExternalLinksInNewTab() {
+  const { origin } = window.location;
+
+  document.querySelectorAll('a[href]').forEach((anchor) => {
+    const href = anchor.getAttribute('href');
+
+    if (!href) return;
+
+    try {
+      const url = new URL(href, origin);
+      if (url.origin !== origin) {
+        anchor.setAttribute('target', '_blank');
+        anchor.setAttribute('rel', 'noopener noreferrer');
+      }
+    } catch {
+      // Malformed href — skip silently
+    }
+  });
+}
+
 // Initialize back to top button
 createBackToTopButton();
+
+// Open external links in a new tab
+openExternalLinksInNewTab();


### PR DESCRIPTION
- Implemented a new function to target all anchor elements with external links.
- Set attributes to open links in a new tab and enhance security with 'noopener noreferrer'.
- Ensured the function handles malformed URLs gracefully.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--ue-multitenant-root--comwrapukreply.aem.live/
- After: https://edge-158--ue-multitenant-root--comwrapukreply.aem.page/
